### PR TITLE
Add addon status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 These addons are intended to be used with [this](https://github.com/Excrulon/Tree-of-Savior-Lua-Mods) addon loader format.
 
 
-#### CabinetCommas
+#### CabinetCommas [![Addon Status Unknown](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-unknown.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Format the silver values for the item listings in the market "sell" and "retrieve" tabs with thousands seperators (commas) for readability. [preview](https://i.imgur.com/0jnNGxx.png)
 
-#### ChannelSurferButtons
+#### ChannelSurferButtons [![Addon Status Unknown](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-unknown.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Quick buttons for previous and next channel. [preview](https://i.imgur.com/IgJLY0a.png)
 
-#### RemoveFPSCounter
+#### RemoveFPSCounter [![Addon Status Unknown](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-unknown.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Hide the FPS counter.
 
-#### RemoveMapBackground
+#### RemoveMapBackground [![Addon Status Unknown](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-unknown.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Remove the gray dimming background when the full map is opened (does not work in cities). [preview](https://i.imgur.com/IfcOlo9.jpg)
 
-#### RemovePetInfo
+#### RemovePetInfo [![Addon Status Unknown](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-unknown.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Hide pet names and/or HP bars. Settings are customizable at the top of the file.


### PR DESCRIPTION
I'm proposing a badge pattern for Tree of Savior addons.
Using these badges, users can easily understand that the system they are using is approved / is safe / have a unknown status / is unsafe.
Read more at [Awesome ToS #addons-badges](https://github.com/lubien/awesome-tos#addons-badges).
Also, I've just added your repo to the [awesome-tos](https://github.com/lubien/awesome-tos) list.
Hope you like the idea.